### PR TITLE
refactor: Convert keywords array to string before sending in response

### DIFF
--- a/routes/upwork-rss/jobs.ts
+++ b/routes/upwork-rss/jobs.ts
@@ -51,7 +51,7 @@ router.post("/get-keywords", async (req, res) => {
     const skills = posts.map((post) => post.skills);
     const keywords = [...new Set(UpworkRSS.filterKeywords(skills.flat()))];
     res.status(200).send({
-      keywords,
+      keywords:keywords.toString(),
     });
   } catch (err) {
     console.log(err);


### PR DESCRIPTION
The code change in `routes/upwork-rss/jobs.ts` modifies the `/get-keywords` endpoint to convert the `keywords` array to a comma-separated string before sending it in the response. This change ensures that the response is compatible with the expected format.

This commit improves the consistency and compatibility of the response data for the `/get-keywords` endpoint.